### PR TITLE
Add Kafka bootstrap server configuration for dev and prod environments

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -31,3 +31,5 @@ mp.messaging.incoming.validation-response.auto.offset.reset=earliest
 mp.messaging.incoming.validation-response.connector=smallrye-kafka
 mp.messaging.incoming.validation-response.topic=validation-response
 mp.messaging.incoming.validation-response.value.deserializer=ch.hftm.blog.model.domain.ValidationResponseDeserializer
+
+kafka.bootstrap.servers=localhost:9092

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -34,3 +34,5 @@ quarkus.flyway.schemas=blogdb
 quarkus.container-image.build=true
 quarkus.container-image.name=ch.hftm/blog-rest-service
 quarkus.container-image.tag=latest
+
+kafka.bootstrap.servers=redpanda-broker:9092


### PR DESCRIPTION
This pull request includes configuration updates to the `application-dev.properties` and `application-prod.properties` files to add Kafka bootstrap server settings.

Configuration updates:

* [`src/main/resources/application-dev.properties`](diffhunk://#diff-cbee934a0dc2d724591feb74d9e4200e997b60b1f2b2a41b51336a0c83ab42b9R34-R35): Added `kafka.bootstrap.servers=localhost:9092` to specify the Kafka server for the development environment.
* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efR37-R38): Added `kafka.bootstrap.servers=redpanda-broker:9092` to specify the Kafka server for the production environment.