### PR TITLE
Fix/kafka bootstrap servers

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -32,4 +32,4 @@ mp.messaging.incoming.validation-response.connector=smallrye-kafka
 mp.messaging.incoming.validation-response.topic=validation-response
 mp.messaging.incoming.validation-response.value.deserializer=ch.hftm.blog.model.domain.ValidationResponseDeserializer
 
-kafka.bootstrap.servers=localhost:9092
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=localhost:9092

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -12,7 +12,7 @@
 # Keycloak URL: http://keycloak:8180
 
 # Quarkus configuration
-quarkus.oidc.auth-server-url=http://keycloak:8180/realms/blog
+quarkus.oidc.auth-server-url=http://localhost:8180/realms/blog
 quarkus.oidc.client-id=backend-service
 quarkus.oidc.credentials.secret=secret!
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -35,4 +35,4 @@ quarkus.container-image.build=true
 quarkus.container-image.name=ch.hftm/blog-rest-service
 quarkus.container-image.tag=latest
 
-kafka.bootstrap.servers=redpanda-broker:9092
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=redpanda-broker:9092


### PR DESCRIPTION
This pull request includes changes to the configuration files for both the development and production environments. The changes primarily involve updating Kafka-related properties to use the `smallrye-kafka` connector.

Configuration updates:

* [`src/main/resources/application-dev.properties`](diffhunk://#diff-cbee934a0dc2d724591feb74d9e4200e997b60b1f2b2a41b51336a0c83ab42b9L35-R35): Changed the Kafka bootstrap server property to use the `smallrye-kafka` connector.
* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efL15-R15): Updated the Keycloak URL to use `localhost` instead of `keycloak`.
* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efL38-R38): Changed the Kafka bootstrap server property to use the `smallrye-kafka` connector.