### PR TITLE
Update Prometheus configuration; rename container and enhance metrics…

### DIFF
--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -1,17 +1,20 @@
-# Global prometheus config. This config is used when the docker compose file starts the prometheus container.
+# This config is used when the docker compose file starts the prometheus container.
+
+# Global prometheus config.
 global:
- scrape_interval:     3s
- evaluation_interval: 10s
- scrape_timeout:      10s
+  scrape_interval: 3s
+  evaluation_interval: 10s
+  #scrape_timeout: 10s
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
-# - "first_rules.yml"
-# - "second_rules.yml"
+  # - "first_rules.yml"
+  # - "second_rules.yml"
 
 # Scrape configuration containing endpoints to scrape (multiple are possible):
- - job_name: 'quarkus-blog-api'
-   metrics_path: '/q/metrics'
-   scrape_interval: 3s
-   static_configs:
-     - targets: ['host.docker.internal:8080']
+scrape_configs:
+  - job_name: 'quarkus-blog-api'
+    metrics_path: '/q/metrics'
+    scrape_interval: 3s
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
   # Prometheus time series database container for metrics persistence
   prometheus:
     image: prom/prometheus
-    container_name: prometheus-monitoring-db
+    container_name: prometheus-timeseries-db
     ports:
       - "9090:9090"
     networks:

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -35,4 +35,11 @@ quarkus.container-image.build=true
 quarkus.container-image.name=ch.hftm/blog-rest-service
 quarkus.container-image.tag=latest
 
+# Kafka messaging broker
 mp.messaging.connector.smallrye-kafka.bootstrap.servers=redpanda-broker:9092
+
+# Micrometer metrics
+quarkus.micrometer.export.prometheus.enabled=true
+quarkus.micrometer.binder-enabled-default=true
+# quarkus.micrometer.export.prometheus.default-registry=true
+quarkus.micrometer.export.prometheus.path=/q/metrics


### PR DESCRIPTION
This pull request includes changes to the configuration files for Prometheus and Docker Compose, as well as updates to the application properties for enabling Kafka messaging and Micrometer metrics.

### Prometheus Configuration Changes:
* [`config/prometheus.yaml`](diffhunk://#diff-a8bae722ee65bf2180f87c589620f83d57f4a6e8e57918c18ec7df037645d1a3L1-R15): Reorganized comments and removed the `scrape_timeout` setting.

### Docker Compose Changes:
* [`docker-compose.yaml`](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L29-R29): Renamed the Prometheus container to `prometheus-timeseries-db`.

### Application Properties Changes:
* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efR38-R45): Added configurations for Kafka messaging broker and Micrometer metrics export to Prometheus.